### PR TITLE
fix for printing negative numbers between -1.0 and 0.0, e.g. "-0.5"

### DIFF
--- a/xformatc.c
+++ b/xformatc.c
@@ -642,6 +642,8 @@ unsigned xvformat(void (*outchar)(void *,char),void *arg,const char * fmt,va_lis
 
                         if (dbl < 0)
                         {
+                            
+                            flags |= FLAG_MINUS;			
                             dbl -= arr;
                             value = (long)dbl;
                             dbl -= (long)value;


### PR DESCRIPTION
In case of printing negative numbers, where the integral part is less
then -1, the negative fractional part was wrongly printed out as
positive number (the '-' sign was missing in the output).