### PR TITLE
Implement variable width and precision specifiers for %s type

### DIFF
--- a/src/xformatc.c
+++ b/src/xformatc.c
@@ -586,6 +586,12 @@ unsigned xvformat(void (*outchar)(void *,char),void *arg,const char * fmt,va_lis
 					param.width = (int)va_arg(args,int);
 				else
 					param.width = param.width * 10 + (c - '0');
+
+				if (param.width < 0)
+				{
+					param.flags |= FLAG_LEFT;
+					param.width *= -1;
+				}
 				break;
 
 			case	ST_DOT:
@@ -770,6 +776,10 @@ unsigned xvformat(void (*outchar)(void *,char),void *arg,const char * fmt,va_lis
 						if (param.out == 0)
 							param.out = (char *)ms_null;
 						param.length = (int)xstrlen(param.out);
+						if ((param.prec != 0) && (param.length > param.prec))
+						{
+							param.length = param.prec;
+						}
 						break;
 
 						/*

--- a/src/xformattest.c
+++ b/src/xformattest.c
@@ -111,6 +111,14 @@ int main(void)
     testFormat("Hello %s","World");
     testFormat("String %4.4s","Large");
     testFormat("String %*.*s",4,4,"Hello");
+    testFormat("String %.*s",4,"Hello");
+    testFormat("String %*.*s",17,5,"Hello World");
+    testFormat("String %-*.*s",17,5,"Hello World");
+    testFormat("String %*.*s",-17,5,"Hello World");
+    testFormat("String %.*s",19,"Hello");
+    testFormat("String %*.*s",17,19,"Hello World");
+    testFormat("String %-*.*s",17,19,"Hello World");
+    testFormat("String %*.*s",-17,19,"Hello World");
     testFormat("integer %05d %+d %d %2d %5d",-7,7,-7,1234,1234);
     testFormat("Integer %+05d %-5d % 5d %05d",1234,1234,1234,1234);
     testFormat("Integer blank % d % d",1,-1);


### PR DESCRIPTION
This commit allows more options for the specifiers for string print. Specifically:

 width specifier to be fully omitted while precision is specified:
        testFormat("String %.*s",4,"Hello");

 width specifier to be bigger than the string length (left padding):
        testFormat("String %*.*s",17,5,"Hello World");

 width specifier to have negative width (right padding)
        testFormat("String %*.*s",-17,5,"Hello World");
        testFormat("String %-*.*s",17,5,"Hello World");

 and also to have precision specifier bigger than length of string:
        testFormat("String %.*s",19,"Hello");
        testFormat("String %*.*s",17,19,"Hello World");
        testFormat("String %*.*s",-17,19,"Hello World");
        testFormat("String %-*.*s",17,19,"Hello World");